### PR TITLE
댓글 번역보기-임시로 노드서버 띄워서 외부 api 테스트  #13

### DIFF
--- a/src/components/comment/CommentOptions.jsx
+++ b/src/components/comment/CommentOptions.jsx
@@ -2,9 +2,12 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { MdMoreHoriz } from "react-icons/md";
 import ButtonsModal from "../common/ButtonsModal";
+// import { useDispatch } from "react-redux";
+// import { __getTranslatedText } from "../../lib/commentApi";
 
 const CommentOptions = () => {
   const [flag, setFlag] = useState(false);
+  // const dispatch = useDispatch();
 
   const showPopup = () => {
     setFlag(true);
@@ -18,11 +21,16 @@ const CommentOptions = () => {
     console.log("삭제");
   };
 
+  // 번역하기
+  const getTranslatedText = async () => {
+    // dispatch(__getTranslatedText());
+  };
+
   return (
     <>
       <CommentDetailWrapper>
         <li>좋아요 2개</li>
-        <li>번역보기</li>
+        <li onClick={getTranslatedText}>번역보기</li>
         <li>
           <MdMoreHoriz onClick={showPopup} />
         </li>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -58,8 +58,6 @@ const HeaderWrapper = styled.div`
   padding: 45px 20px 12px 20px;
   color: rgb(38, 38, 38);
   h1 {
-    @import url("https://fonts.googleapis.com/css2?family=Oleo+Script&display=swap");
-    font-family: "Oleo Script", cursive;
     font-size: 25px;
     margin-bottom: 60px;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,3 @@
-@font-face {
-  font-family: "Pretendard-Regular";
-  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
-    format("woff");
-  font-weight: 400;
-  font-style: normal;
-}
-
 html,
 body,
 div,
@@ -93,7 +85,6 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font-family: "Pretendard-Regular";
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -5,6 +5,7 @@ const api = axios.create({
   headers: {
     "content-type": "application/json;charset=UTF-8",
     accept: "application/json,",
+    "Access-Control-Allow-Origin": "*",
     withCredentials: true,
   },
 });

--- a/src/lib/commentApi.js
+++ b/src/lib/commentApi.js
@@ -1,15 +1,22 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import api from "./api";
+// import api from "./api";
 
-// 예시
-// export const __getUserPosts = createAsyncThunk(
-//   "getUserPosts",
-//   async (payload, thunkAPI) => {
-//     try {
-//       const response = await api.get(`/api/posts/user/${payload}`);
-//       return thunkAPI.fulfillWithValue(response.data);
-//     } catch (error) {
-//       return thunkAPI.rejectWithValue(error);
-//     }
-//   }
-// );
+// 댓글 번역하기
+export const __getTranslatedText = createAsyncThunk(
+  "getTranslatedText",
+  async (payload, thunkAPI) => {
+    // To-Do: 로컬 테스트서버 -> 백엔드 api서버
+    // try {
+    //   const text = "hi! my name is jeonyujin.";
+    //   const response = await api.get(
+    //     `http://127.0.0.1:4000/translate?text=${text}`
+    //   );
+    //   console.log(
+    //     "==========================번역결과=============================="
+    //   );
+    //   console.log(response.data);
+    // } catch (error) {
+    //   return thunkAPI.rejectWithValue(error);
+    // }
+  }
+);


### PR DESCRIPTION
- 사용한 외부 API: 파파고 번역 API
- 임시로 로컬에서 노드로 서버 띄워서 테스트한 결과 정상적으로 번역되는 것을 확인했다.
- 백엔드팀이 추후에 번역 api를 만들어주면 그 api를 호출하도록 수정해야함. 